### PR TITLE
feat: [Tier 2] DadJokes Plugin Implementation (#6)

### DIFF
--- a/src/Imeritas.Agent.DadJokes.Tests/DadJokesPluginTests.cs
+++ b/src/Imeritas.Agent.DadJokes.Tests/DadJokesPluginTests.cs
@@ -1,0 +1,129 @@
+using System.Reflection;
+using Imeritas.Agent.DadJokes.Plugin;
+using Imeritas.Agent.Extensions;
+using Imeritas.Agent.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Imeritas.Agent.DadJokes.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="DadJokesPlugin"/> covering kernel function behavior,
+/// system prompt contribution, and classification metadata.
+/// </summary>
+public class DadJokesPluginTests
+{
+    private readonly DadJokesPlugin _plugin;
+
+    public DadJokesPluginTests()
+    {
+        var tenantContext = Substitute.For<ITenantContext>();
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(Substitute.For<ILogger>());
+        var httpClientFactory = Substitute.For<IHttpClientFactory>();
+        var configuration = Substitute.For<IConfiguration>();
+
+        var host = new PluginHostContext(tenantContext, loggerFactory, httpClientFactory, configuration);
+        _plugin = new DadJokesPlugin(host);
+    }
+
+    // ── TellJokeAsync: happy path ────────────────────────────────────────
+
+    [Fact]
+    public async Task TellJokeAsync_NoCategory_ReturnsSetupPunchlineFormat()
+    {
+        var result = await _plugin.TellJokeAsync();
+
+        Assert.Contains("\n\n", result);
+        var parts = result.Split("\n\n", 2);
+        Assert.Equal(2, parts.Length);
+        Assert.False(string.IsNullOrWhiteSpace(parts[0]), "Setup should not be empty");
+        Assert.False(string.IsNullOrWhiteSpace(parts[1]), "Punchline should not be empty");
+    }
+
+    [Fact]
+    public async Task TellJokeAsync_ValidCategory_ReturnsJoke()
+    {
+        var result = await _plugin.TellJokeAsync("food");
+
+        Assert.Contains("\n\n", result);
+        Assert.DoesNotContain("Error", result);
+        Assert.DoesNotContain("No jokes found", result);
+    }
+
+    [Fact]
+    public async Task TellJokeAsync_InvalidCategory_ReturnsNoJokesFoundMessage()
+    {
+        var result = await _plugin.TellJokeAsync("nonexistent");
+
+        Assert.Contains("No jokes found in category 'nonexistent'", result);
+        Assert.Contains("Try a different category!", result);
+    }
+
+    // ── TellJokeAsync: exception path ────────────────────────────────────
+
+    [Fact]
+    public async Task TellJokeAsync_OnException_ReturnsErrorMessage_DoesNotThrow()
+    {
+        // Arrange: force an exception by nulling out the joke service via reflection
+        var field = typeof(DadJokesPlugin).GetField(
+            "_jokeService",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        field!.SetValue(_plugin, null);
+
+        // Act — should not throw
+        var result = await _plugin.TellJokeAsync();
+
+        // Assert
+        Assert.StartsWith("Error telling joke:", result);
+    }
+
+    // ── GetSystemPromptContributionAsync ──────────────────────────────────
+
+    [Fact]
+    public async Task GetSystemPromptContributionAsync_ReturnsNonNullStringWithCategories()
+    {
+        var result = await _plugin.GetSystemPromptContributionAsync("test-tenant");
+
+        Assert.NotNull(result);
+        Assert.Contains("animals", result);
+        Assert.Contains("food", result);
+        Assert.Contains("tech", result);
+        Assert.Contains("work", result);
+        Assert.Contains("science", result);
+        Assert.Contains("general", result);
+    }
+
+    // ── DirectlyInvocableFunctions ────────────────────────────────────────
+
+    [Fact]
+    public void DirectlyInvocableFunctions_ContainsTellJoke()
+    {
+        Assert.Contains("tell_joke", _plugin.DirectlyInvocableFunctions);
+    }
+
+    // ── SlashCommands ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void SlashCommands_ContainsJokeCommand()
+    {
+        Assert.Single(_plugin.SlashCommands);
+        Assert.Equal("/joke", _plugin.SlashCommands[0].Command);
+        Assert.Equal("dad_joke", _plugin.SlashCommands[0].TaskType);
+    }
+
+    // ── ClassificationExamples ────────────────────────────────────────────
+
+    [Fact]
+    public void ClassificationExamples_ReturnsTwoExamplesForDadJokeTask()
+    {
+        Assert.Equal(2, _plugin.ClassificationExamples.Count);
+        Assert.All(_plugin.ClassificationExamples, ex =>
+        {
+            Assert.Equal("[TASK:dad_joke]", ex.ClassificationPrefix);
+            Assert.Equal("DadJokes", ex.SourceName);
+        });
+    }
+}

--- a/src/Imeritas.Agent.DadJokes/Plugin/DadJokesPlugin.cs
+++ b/src/Imeritas.Agent.DadJokes/Plugin/DadJokesPlugin.cs
@@ -21,7 +21,6 @@ namespace Imeritas.Agent.DadJokes.Plugin;
 public class DadJokesPlugin : IAgentPlugin, IClassificationContributor, IConfigurablePlugin<DadJokesSettings>
 {
     // ── Fields ───────────────────────────────────────────────────────────
-    private readonly PluginHostContext _host;
     private readonly ILogger _logger;
     private readonly JokeService _jokeService = new();
 
@@ -33,7 +32,6 @@ public class DadJokesPlugin : IAgentPlugin, IClassificationContributor, IConfigu
     /// </summary>
     public DadJokesPlugin(PluginHostContext host)
     {
-        _host = host;
         _logger = host.LoggerFactory.CreateLogger<DadJokesPlugin>();
     }
 
@@ -83,29 +81,27 @@ public class DadJokesPlugin : IAgentPlugin, IClassificationContributor, IConfigu
     /// </summary>
     [KernelFunction("tell_joke")]
     [Description("Tells a dad joke, optionally filtered by category")]
-    public async Task<string> TellJokeAsync(
+    public Task<string> TellJokeAsync(
         [Description("Optional joke category (e.g., 'programming', 'food'). Leave empty for any category.")]
         string? category = null)
     {
         try
         {
-            // Resolve tenant settings at call time (singleton plugin pattern)
-            var settings = await _host.TenantContext.GetPluginSettingsAsync<DadJokesSettings>(PluginKey);
+            // If a category was requested but has no matches, return feedback
+            if (!string.IsNullOrWhiteSpace(category) && _jokeService.GetByCategory(category).Count == 0)
+                return Task.FromResult($"No jokes found in category '{category}'. Try a different category!");
 
-            // Get joke from service
+            // Get joke from service (falls back to random if category is null/empty)
             var joke = _jokeService.GetRandomByCategory(category);
 
-            if (joke == null)
-                return $"No jokes found{(category != null ? $" in category '{category}'" : "")}. Try a different category!";
-
             // Return in 'Setup\n\nPunchline' format per AC
-            return $"{joke.Setup}\n\n{joke.Punchline}";
+            return Task.FromResult($"{joke.Setup}\n\n{joke.Punchline}");
         }
         catch (Exception ex)
         {
             // Return error strings, never throw (AC + framework convention)
             _logger.LogError(ex, "Error telling joke for category {Category}", category);
-            return $"Error telling joke: {ex.Message}";
+            return Task.FromResult($"Error telling joke: {ex.Message}");
         }
     }
 


### PR DESCRIPTION
## Summary

Automated implementation for #6.

Implementation is complete. Here's a summary of what was done:

## Created: `src/Imeritas.Agent.DadJokes/Plugin/DadJokesPlugin.cs`

### Acceptance Criteria Checklist — All Met ✓

| Criterion | Status |
|-----------|--------|
| File at `src/Imeritas.Agent.DadJokes/Plugin/DadJokesPlugin.cs` | ✓ |
| Namespace `Imeritas.Agent.DadJokes.Plugin` | ✓ |
| `Name` → `"DadJokes"`, `DisplayName` → `"Dad Jokes"` | ✓ |
| Constructor accepts `PluginHostContext` | ✓ |
| `tell_joke` KernelFunction with `string? category` parameter | ✓ |
| Successful joke returns `"Setup\n\nPunchline"` format | ✓ |
| Exception returns `"Error telling joke: ..."` (no throw) | ✓ |
| `DirectlyInvocableFunctions` contains `"tell_joke"` | ✓ |
| `SlashCommands` has `"/joke"` → TaskType `"dad_joke"` | ✓ |
| `ClassificationExamples` has 2 entries with `"[TASK:dad_joke]"` prefix | ✓ |
| `ClassificationHints.TaskType` is `"dad_joke"` with keywords | ✓ |
| `GetSystemPromptContributionAsync` returns non-null string mentioning categories | ✓ |
| Implements `IConfigurablePlugin<DadJokesSettings>` | ✓ |
| `dotnet build Imeritas.Agent.DadJokes.slnx` succeeds with 0 errors, 0 warnings | ✓ |

### Key Adaptation from Plan
- **JokeService is instance-based** (not static as the plan assumed) — created a `private readonly JokeService _jokeService = new()` field since JokeService is stateless and documented as safe to instantiate directly.

Closes #6

---
*Generated by Imeritas.Agent delivery workflow.*