### PR TITLE
feat: [Tier 2] DadJoke Orchestrator Implementation (#7)

### DIFF
--- a/src/Imeritas.Agent.DadJokes/Orchestrator/DadJokeOrchestrator.cs
+++ b/src/Imeritas.Agent.DadJokes/Orchestrator/DadJokeOrchestrator.cs
@@ -1,0 +1,111 @@
+using Imeritas.Agent.DadJokes.Services;
+using Imeritas.Agent.Models;
+using Imeritas.Agent.Orchestrators;
+using Imeritas.Agent.Services;
+using Microsoft.Extensions.Logging;
+using AgentTaskStatus = Imeritas.Agent.Models.TaskStatus;
+
+namespace Imeritas.Agent.DadJokes.Orchestrator;
+
+/// <summary>
+/// Orchestrator for dad joke tasks. Handles the 'dad_joke' task type by
+/// fetching a joke from <see cref="JokeService"/> (optionally filtered by
+/// category) and persisting the result via <see cref="IStorageService"/>.
+/// </summary>
+public class DadJokeOrchestrator : ITaskOrchestrator, IClassificationContributor
+{
+    private readonly IStorageService _storage;
+    private readonly ILogger<DadJokeOrchestrator> _logger;
+    private readonly JokeService _jokeService = new();
+
+    public DadJokeOrchestrator(
+        IStorageService storage,
+        ILogger<DadJokeOrchestrator> logger)
+    {
+        _storage = storage;
+        _logger = logger;
+    }
+
+    // ── ITaskOrchestrator Identity ────────────────────────────────────
+
+    /// <inheritdoc />
+    public string Name => "DadJoke";
+
+    /// <inheritdoc />
+    public int Priority => 50;
+
+    /// <inheritdoc />
+    public bool CanHandle(string tenantId, string? taskType, string prompt)
+        => taskType == "dad_joke";
+
+    // ── Execution ─────────────────────────────────────────────────────
+
+    /// <inheritdoc />
+    public async Task<AgentTask> ExecuteAsync(
+        string tenantId,
+        string userId,
+        string prompt,
+        string? taskType = null,
+        Dictionary<string, object>? inputData = null,
+        string? parentTaskId = null,
+        CancellationToken cancellationToken = default,
+        ITaskProgressCallback? progress = null)
+    {
+        var task = new AgentTask
+        {
+            UserId = userId,
+            Title = "Dad Joke",
+            Description = prompt,
+            Type = TaskType.Manual,
+            Status = AgentTaskStatus.Running,
+            StartedAt = DateTime.UtcNow,
+            ParentTaskId = parentTaskId
+        };
+
+        try
+        {
+            // Extract optional category from inputData
+            string? category = null;
+            if (inputData?.TryGetValue("category", out var categoryObj) == true)
+                category = categoryObj?.ToString();
+
+            _logger.LogInformation(
+                "Executing dad joke task for user {UserId}, category {Category}",
+                userId, category ?? "random");
+
+            // Get joke — falls back to random when category is null/empty/unknown
+            var joke = _jokeService.GetRandomByCategory(category);
+            var jokeText = $"{joke.Setup}\n\n{joke.Punchline}";
+
+            task.OutputData["result"] = jokeText;
+
+            if (progress != null)
+                await progress.ReportAsync("Here's a dad joke for you!");
+
+            task.Status = AgentTaskStatus.Completed;
+            task.CompletedAt = DateTime.UtcNow;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error executing dad joke task for user {UserId}", userId);
+            task.Status = AgentTaskStatus.Failed;
+            task.ErrorMessage = ex.Message;
+        }
+        finally
+        {
+            task.LastUpdatedAt = DateTime.UtcNow;
+            await _storage.SaveTaskAsync(tenantId, task);
+        }
+
+        return task;
+    }
+
+    // ── IClassificationContributor ────────────────────────────────────
+
+    /// <inheritdoc />
+    public ClassificationHints ClassificationHints => new()
+    {
+        TaskType = "dad_joke",
+        TaskTypeKeywords = new[] { "dad joke", "joke", "funny", "punchline" }
+    };
+}


### PR DESCRIPTION
## Summary

Automated implementation for #7.

Implementation complete. Here's a summary:

## Created File

**`src/Imeritas.Agent.DadJokes/Orchestrator/DadJokeOrchestrator.cs`**

### What it does
- Implements `ITaskOrchestrator` and `IClassificationContributor` for the `dad_joke` task type
- Handles task execution by fetching a joke from `JokeService` (optionally filtered by category from `inputData`)
- Persists task state via `IStorageService.SaveTaskAsync` in a `finally` block (guarantees persistence for both success and failure paths)
- Reports progress via `ITaskProgressCallback` when available
- Contributes classification hints (keywords: "dad joke", "joke", "funny", "punchline") as a complementary signal to the plugin's existing classification metadata

### Key deviation from plan
- Added `using AgentTaskStatus = Imeritas.Agent.Models.TaskStatus;` alias because the plan's `Models.TaskStatus` references resolved to the local `Imeritas.Agent.DadJokes.Models` namespace (which contains `Joke` and `DadJokesSettings`) instead of the framework's `Imeritas.Agent.Models.TaskStatus` enum. This follows the same pattern used in the existing reference orchestrator from git history.

### Build verification
- **Build succeeded** — 0 errors, 0 warnings (the NU1801 warning about the nuget.org source is a pre-existing environment/path issue unrelated to the code)
- Full solution build (`dotnet build Imeritas.Agent.DadJokes.slnx`) cannot complete due to a missing `GITHUB_TOKEN` for the GitHub Packages NuGet feed, but the main project compiles cleanly

Closes #7

---
*Generated by Imeritas.Agent delivery workflow.*