### PR TITLE
feat: [Tier 3] Comprehensive Unit Tests (#8)

### DIFF
--- a/src/Imeritas.Agent.DadJokes.Tests/Orchestrator/DadJokeOrchestratorTests.cs
+++ b/src/Imeritas.Agent.DadJokes.Tests/Orchestrator/DadJokeOrchestratorTests.cs
@@ -1,0 +1,139 @@
+using Imeritas.Agent.DadJokes.Orchestrator;
+using Imeritas.Agent.Models;
+using Imeritas.Agent.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+using AgentTaskStatus = Imeritas.Agent.Models.TaskStatus;
+
+namespace Imeritas.Agent.DadJokes.Tests.Orchestrator;
+
+/// <summary>
+/// Unit tests for <see cref="DadJokeOrchestrator"/> covering routing (CanHandle),
+/// execution (ExecuteAsync), persistence, and task metadata.
+/// </summary>
+public class DadJokeOrchestratorTests
+{
+    private readonly IStorageService _storage;
+    private readonly DadJokeOrchestrator _sut;
+
+    public DadJokeOrchestratorTests()
+    {
+        _storage = Substitute.For<IStorageService>();
+        var logger = Substitute.For<ILogger<DadJokeOrchestrator>>();
+        _sut = new DadJokeOrchestrator(_storage, logger);
+    }
+
+    // ── CanHandle ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void CanHandle_DadJokeTaskType_ReturnsTrue()
+    {
+        Assert.True(_sut.CanHandle("t1", "dad_joke", "tell me a joke"));
+    }
+
+    [Fact]
+    public void CanHandle_OtherTaskType_ReturnsFalse()
+    {
+        Assert.False(_sut.CanHandle("t1", "email", "send email"));
+    }
+
+    [Fact]
+    public void CanHandle_NullTaskType_ReturnsFalse()
+    {
+        Assert.False(_sut.CanHandle("t1", null, "hello"));
+    }
+
+    // ── ExecuteAsync ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_WithCategory_ReturnsCompletedTask()
+    {
+        var inputData = new Dictionary<string, object> { ["category"] = "food" };
+
+        var task = await _sut.ExecuteAsync(
+            tenantId: "t1",
+            userId: "u1",
+            prompt: "tell me a joke",
+            taskType: "dad_joke",
+            inputData: inputData);
+
+        Assert.Equal(AgentTaskStatus.Completed, task.Status);
+        Assert.True(task.OutputData.ContainsKey("result"));
+        var result = task.OutputData["result"]?.ToString();
+        Assert.False(string.IsNullOrEmpty(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithoutCategory_ReturnsCompletedTask()
+    {
+        var task = await _sut.ExecuteAsync(
+            tenantId: "t1",
+            userId: "u1",
+            prompt: "tell me a joke",
+            taskType: "dad_joke",
+            inputData: new Dictionary<string, object>());
+
+        Assert.Equal(AgentTaskStatus.Completed, task.Status);
+        Assert.True(task.OutputData.ContainsKey("result"));
+        var result = task.OutputData["result"]?.ToString();
+        Assert.False(string.IsNullOrEmpty(result));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NullInputData_ReturnsCompletedTask()
+    {
+        var task = await _sut.ExecuteAsync(
+            tenantId: "t1",
+            userId: "u1",
+            prompt: "tell me a joke",
+            taskType: "dad_joke",
+            inputData: null);
+
+        Assert.Equal(AgentTaskStatus.Completed, task.Status);
+        Assert.True(task.OutputData.ContainsKey("result"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CompletedTask_SetsTimestamps()
+    {
+        var task = await _sut.ExecuteAsync(
+            tenantId: "t1",
+            userId: "u1",
+            prompt: "tell me a joke",
+            taskType: "dad_joke",
+            inputData: new Dictionary<string, object>());
+
+        Assert.NotNull(task.StartedAt);
+        Assert.NotNull(task.CompletedAt);
+        Assert.Equal(AgentTaskStatus.Completed, task.Status);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_CallsSaveTaskAsync()
+    {
+        await _sut.ExecuteAsync(
+            tenantId: "t1",
+            userId: "u1",
+            prompt: "tell me a joke",
+            taskType: "dad_joke",
+            inputData: new Dictionary<string, object>());
+
+        await _storage.Received().SaveTaskAsync("t1", Arg.Any<AgentTask>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SetsOutputDataResult()
+    {
+        var task = await _sut.ExecuteAsync(
+            tenantId: "t1",
+            userId: "u1",
+            prompt: "tell me a joke",
+            taskType: "dad_joke",
+            inputData: new Dictionary<string, object>());
+
+        var result = task.OutputData["result"]?.ToString();
+        Assert.NotNull(result);
+        Assert.Contains("\n\n", result);
+    }
+}

--- a/src/Imeritas.Agent.DadJokes.Tests/Plugin/DadJokesPluginTests.cs
+++ b/src/Imeritas.Agent.DadJokes.Tests/Plugin/DadJokesPluginTests.cs
@@ -7,11 +7,11 @@ using Microsoft.Extensions.Logging;
 using NSubstitute;
 using Xunit;
 
-namespace Imeritas.Agent.DadJokes.Tests;
+namespace Imeritas.Agent.DadJokes.Tests.Plugin;
 
 /// <summary>
-/// Unit tests for <see cref="DadJokesPlugin"/> covering kernel function behavior,
-/// system prompt contribution, and classification metadata.
+/// Unit tests for <see cref="DadJokesPlugin"/> covering identity properties,
+/// kernel function behavior, system prompt contribution, and classification metadata.
 /// </summary>
 public class DadJokesPluginTests
 {
@@ -29,7 +29,20 @@ public class DadJokesPluginTests
         _plugin = new DadJokesPlugin(host);
     }
 
-    // ── TellJokeAsync: happy path ────────────────────────────────────────
+    // ── Plugin Identity ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Name_ReturnsExpectedValue()
+    {
+        Assert.Equal("DadJokes", _plugin.Name);
+        Assert.Equal("DadJokes", _plugin.PluginKey);
+        Assert.Equal("DadJokes", _plugin.KernelPluginName);
+        Assert.Null(_plugin.InstanceName);
+        Assert.Equal("Dad Jokes", _plugin.DisplayName);
+        Assert.False(string.IsNullOrEmpty(_plugin.Description));
+    }
+
+    // ── TellJokeAsync: happy path ─────────────────────────────────────────
 
     [Fact]
     public async Task TellJokeAsync_NoCategory_ReturnsSetupPunchlineFormat()
@@ -62,7 +75,7 @@ public class DadJokesPluginTests
         Assert.Contains("Try a different category!", result);
     }
 
-    // ── TellJokeAsync: exception path ────────────────────────────────────
+    // ── TellJokeAsync: exception path ─────────────────────────────────────
 
     [Fact]
     public async Task TellJokeAsync_OnException_ReturnsErrorMessage_DoesNotThrow()
@@ -80,7 +93,7 @@ public class DadJokesPluginTests
         Assert.StartsWith("Error telling joke:", result);
     }
 
-    // ── GetSystemPromptContributionAsync ──────────────────────────────────
+    // ── GetSystemPromptContributionAsync ───────────────────────────────────
 
     [Fact]
     public async Task GetSystemPromptContributionAsync_ReturnsNonNullStringWithCategories()
@@ -96,7 +109,7 @@ public class DadJokesPluginTests
         Assert.Contains("general", result);
     }
 
-    // ── DirectlyInvocableFunctions ────────────────────────────────────────
+    // ── DirectlyInvocableFunctions ─────────────────────────────────────────
 
     [Fact]
     public void DirectlyInvocableFunctions_ContainsTellJoke()
@@ -104,7 +117,7 @@ public class DadJokesPluginTests
         Assert.Contains("tell_joke", _plugin.DirectlyInvocableFunctions);
     }
 
-    // ── SlashCommands ─────────────────────────────────────────────────────
+    // ── SlashCommands ──────────────────────────────────────────────────────
 
     [Fact]
     public void SlashCommands_ContainsJokeCommand()
@@ -114,7 +127,7 @@ public class DadJokesPluginTests
         Assert.Equal("dad_joke", _plugin.SlashCommands[0].TaskType);
     }
 
-    // ── ClassificationExamples ────────────────────────────────────────────
+    // ── ClassificationExamples ─────────────────────────────────────────────
 
     [Fact]
     public void ClassificationExamples_ReturnsTwoExamplesForDadJokeTask()

--- a/src/Imeritas.Agent.DadJokes.Tests/Services/JokeServiceTests.cs
+++ b/src/Imeritas.Agent.DadJokes.Tests/Services/JokeServiceTests.cs
@@ -1,0 +1,122 @@
+using Imeritas.Agent.DadJokes.Services;
+using Xunit;
+
+namespace Imeritas.Agent.DadJokes.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="JokeService"/> — a stateless, in-memory joke repository.
+/// </summary>
+public class JokeServiceTests
+{
+    private readonly JokeService _sut = new();
+
+    // ── GetByCategory ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetByCategory_ValidCategory_ReturnsMatchingJokes()
+    {
+        var result = _sut.GetByCategory("food");
+
+        Assert.NotEmpty(result);
+        Assert.All(result, joke =>
+            Assert.Contains("food", joke.Categories, StringComparer.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void GetByCategory_UnknownCategory_ReturnsEmptyList()
+    {
+        var result = _sut.GetByCategory("nonexistent");
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GetByCategory_NullCategory_ReturnsEmptyList()
+    {
+        var result = _sut.GetByCategory(null!);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GetByCategory_EmptyString_ReturnsEmptyList()
+    {
+        Assert.Empty(_sut.GetByCategory(""));
+        Assert.Empty(_sut.GetByCategory("  "));
+    }
+
+    [Fact]
+    public void GetByCategory_CaseInsensitive_ReturnsSameResults()
+    {
+        var upper = _sut.GetByCategory("TECH");
+        var lower = _sut.GetByCategory("tech");
+
+        Assert.Equal(upper.Count, lower.Count);
+    }
+
+    // ── GetRandom ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetRandom_ReturnsNonNullJoke()
+    {
+        var joke = _sut.GetRandom();
+
+        Assert.NotNull(joke);
+        Assert.False(string.IsNullOrWhiteSpace(joke.Setup));
+    }
+
+    // ── GetRandomByCategory ───────────────────────────────────────────────
+
+    [Fact]
+    public void GetRandomByCategory_ValidCategory_ReturnsJokeFromCategory()
+    {
+        var joke = _sut.GetRandomByCategory("animals");
+
+        Assert.NotNull(joke);
+        Assert.Contains("animals", joke.Categories, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GetRandomByCategory_NullCategory_FallsBackToRandom()
+    {
+        var joke = _sut.GetRandomByCategory(null);
+
+        Assert.NotNull(joke);
+    }
+
+    [Fact]
+    public void GetRandomByCategory_UnknownCategory_FallsBackToRandom()
+    {
+        var joke = _sut.GetRandomByCategory("nonexistent");
+
+        Assert.NotNull(joke);
+    }
+
+    // ── GetCategories ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetCategories_ReturnsSortedDistinctList()
+    {
+        var result = _sut.GetCategories();
+
+        Assert.True(result.Count >= 6, $"Expected at least 6 categories but got {result.Count}");
+        Assert.Contains("animals", result, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("food", result, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("general", result, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("science", result, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("tech", result, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("work", result, StringComparer.OrdinalIgnoreCase);
+
+        // Verify alphabetical sort order
+        var sorted = result.OrderBy(c => c, StringComparer.OrdinalIgnoreCase).ToList();
+        Assert.Equal(sorted, result);
+    }
+
+    // ── Count ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Count_ReturnsExpectedTotal()
+    {
+        Assert.Equal(20, _sut.Count);
+    }
+}


### PR DESCRIPTION
## Summary

Automated implementation for #8.

All tasks are complete. Here's a summary of what was done:

## ✅ Implementation Complete

The previous attempt had already created all the correct test files — the timeout was caused by NuGet authentication retries against GitHub Packages, not by code issues. I fixed the build by restoring packages from the local NuGet cache.

### Files in place:
1. **`src/Imeritas.Agent.DadJokes.Tests/Services/JokeServiceTests.cs`** — 11 tests covering `JokeService` (category lookup, null/empty handling, case insensitivity, random selection, category listing, count)
2. **`src/Imeritas.Agent.DadJokes.Tests/Plugin/DadJokesPluginTests.cs`** — 9 tests covering `DadJokesPlugin` (identity props, tell_joke happy/error paths, system prompt, slash commands, classification examples)
3. **`src/Imeritas.Agent.DadJokes.Tests/Orchestrator/DadJokeOrchestratorTests.cs`** — 9 tests covering `DadJokeOrchestrator` (CanHandle routing, ExecuteAsync with/without category, null input, timestamps, SaveTaskAsync persistence, output format)
4. **Old root-level `DadJokesPluginTests.cs`** — already deleted

### Verification Results:
- **Build:** ✅ `dotnet build Imeritas.Agent.DadJokes.slnx` — 0 errors, 0 warnings
- **Tests:** ✅ `dotnet test src/Imeritas.Agent.DadJokes.Tests` — **29 passed, 0 failed** (11 + 9 + 9)

Closes #8

---
*Generated by Imeritas.Agent delivery workflow.*